### PR TITLE
Fix SO_REUSEPORT for bare-metal multi-app coexistence

### DIFF
--- a/Grasshopper/grasshopper/api.py
+++ b/Grasshopper/grasshopper/api.py
@@ -197,6 +197,13 @@ def process_compare_rdf_queue(task_queue: Queue, processing_task_queue: Queue, f
             print(f"Error processing task: {e}")
 
 
+def _local_name(uri: str) -> str:
+    """Extract the local name from a URI, handling both '#' and '/' separators."""
+    if "#" in uri:
+        return uri.split("#")[-1]
+    return uri.split("/")[-1]
+
+
 def build_networkx_graph(g: Graph):
     """
     Build a networkx graph from the BACnet RDF graph.
@@ -234,8 +241,8 @@ def build_networkx_graph(g: Graph):
             if "rdf_diff_source" in edge_label:
                 rdf_diff_list.append((u, v, edge_label))
             elif all(edge.value not in edge_label for edge in BACnetEdgeType):
-                label = edge_label.split("#")[-1]
-                val = str(v).split("#")[-1]
+                label = _local_name(str(edge_label))
+                val = _local_name(str(v))
                 if str(u) in node_data:
                     node_data[str(u)][label] = val
                 else:

--- a/Grasshopper/grasshopper/bacpypes3_scanner.py
+++ b/Grasshopper/grasshopper/bacpypes3_scanner.py
@@ -4,6 +4,8 @@ File contains the bacpypes3_scanner class which is used to scan the network for 
 import asyncio
 import ipaddress
 import logging
+import os
+import socket
 from typing import Any, Dict, List, Optional, Set, Union
 
 import netifaces
@@ -513,13 +515,32 @@ class bacpypes3_scanner:
             _log.warning(f"Failed to determine local subnet from '{address}': {e}")
             return None
 
+    def _create_reuse_socket(self, address: str, port: int) -> socket.socket:
+        """
+        Create a UDP socket with SO_REUSEPORT so multiple BACnet applications
+        can share the same broadcast address on a bare-metal host.
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if hasattr(socket, "SO_REUSEPORT") and "nt" not in os.name:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.bind((address, port))
+        sock.setblocking(False)
+        _log.info(f"Created reuse socket bound to {address}:{port}")
+        return sock
+
     async def set_application(self, graph: Graph) -> Application:
         """
-        Set the application address for the BACnet analysis
+        Set the application address for the BACnet analysis.
+        Creates a UDP socket with SO_REUSEPORT to allow multiple BACnet
+        applications to coexist on the same port on bare-metal hosts.
+
+        Builds the Application stack manually (rather than using from_args)
+        so we can pass a pre-bound socket to the IPv4 link layer.
         """
         _log.debug("bacpypes3_scanner: set_application")
         settings = self.bacpypes_settings.copy()
-        bbmd_ips = self.get_bbmd_ips(graph)
         settings["bbmd"] = self.bacpypes_settings.get("bbmd", None)
 
         # Register VendorInfo before creating Application (required for non-999 vendor IDs)
@@ -527,23 +548,80 @@ class bacpypes3_scanner:
         if vendorid != 999:
             try:
                 vendor_info = VendorInfo(vendorid)
-                # Register standard object classes so device has proper defaults
                 vendor_info.register_object_class(ObjectType.device, DeviceObject)
                 _log.debug(f"Registered VendorInfo for vendor ID {vendorid}")
             except RuntimeError as e:
-                # Vendor ID may already be registered
                 _log.debug(f"VendorInfo for vendor ID {vendorid} already registered: {e}")
 
         # Use SimpleArgumentParser to get proper bacpypes3 defaults
         parser = SimpleArgumentParser()
-        args = parser.parse_args([])  # Parse empty args to get all defaults
-
-        # Override defaults with our config values
+        args = parser.parse_args([])
         for key, value in settings.items():
             setattr(args, key, value)
 
+        # Parse address for socket binding
+        addr_str = settings.get("address", "")
+        bind_ip = addr_str.split("/")[0].split(":")[0] if addr_str else "0.0.0.0"
+        bind_port = int(addr_str.split(":")[-1]) if ":" in addr_str else 47808
+
+        # Create socket with SO_REUSEPORT for bare-metal coexistence
+        bind_sock = self._create_reuse_socket(bind_ip, bind_port)
+
+        # Build the Application stack manually to pass bind_socket through.
+        # This mirrors what Application.from_args + from_object_list + add_object
+        # does, but gives us control over the link layer socket.
+        from bacpypes3.vendor import get_vendor_info
+        from bacpypes3.local.networkport import NetworkPortObject
+        from bacpypes3.ipv4.link import NormalLinkLayer as NormalLinkLayer_ipv4
+        from bacpypes3.netservice import NetworkServiceAccessPoint, NetworkServiceElement
+        from bacpypes3.appservice import ApplicationServiceAccessPoint
+
+        vi = get_vendor_info(vendorid)
+        device_object_class = vi.get_object_class(ObjectType.device)
+        device_object = device_object_class(
+            objectIdentifier=("device", int(args.instance)),
+            objectName=args.name,
+        )
+
+        # Create the application
+        app = Application(device_info_cache=None)
+        app.asap = ApplicationServiceAccessPoint(device_object, app.device_info_cache)
+        app.nsap = NetworkServiceAccessPoint()
+        app.nse = NetworkServiceElement()
+        bind(app.nse, app.nsap)
+        bind(app, app.asap, app.nsap)
+        app.add_object(device_object)
+
+        # Build the network port object (but don't add_object it — we'll
+        # wire the link layer manually with our socket)
+        network_port_class = vi.get_object_class(ObjectType.networkPort)
+        address = args.address if args.address else "host"
+        network_port_object = network_port_class(
+            address,
+            objectIdentifier=("network-port", 1),
+            objectName="NetworkPort-1",
+            networkNumber=args.network,
+            networkNumberQuality="configured" if args.network else "unknown",
+        )
+
+        link_address = network_port_object.address
+        _log.info(f"Creating link layer with SO_REUSEPORT socket on {bind_ip}:{bind_port}")
+        link_layer = NormalLinkLayer_ipv4(link_address, bind_socket=bind_sock)
+
+        app.link_layers[network_port_object.objectIdentifier] = link_layer
+        if args.network and args.network != 0:
+            app.nsap.bind(link_layer, net=args.network, address=link_address)
+        else:
+            app.nsap.bind(link_layer, address=link_address)
+
+        # Register the network port object directly in the app's dictionaries
+        # without calling add_object, which would create a second link layer
+        app.objectName[network_port_object.objectName] = network_port_object
+        app.objectIdentifier[network_port_object.objectIdentifier] = network_port_object
+        network_port_object._app = app
+
         _log.debug(f"Application config: {args}")
-        return Application.from_args(args)
+        return app
 
     def get_networks_from_graph(self, g: rdflib.Graph) -> Set[int]:
         """Return a set of network numbers from the graph"""

--- a/Grasshopper/requirements.txt
+++ b/Grasshopper/requirements.txt
@@ -1,5 +1,5 @@
 rdflib == 7.0.0
-bacpypes3@git+https://github.com/JoelBender/BACpypes3.git@main
+bacpypes3 >= 0.0.106
 pyvis == 0.3.2
 pydantic == 2.6.4
 fastapi == 0.112.0

--- a/grasshopper-frontend/src/components/NetworkDiagram.vue
+++ b/grasshopper-frontend/src/components/NetworkDiagram.vue
@@ -1364,64 +1364,61 @@ export default {
         }
       })
 
-      // Draw BDT/FDT edges for selected BBMD in tree mode
-      if (this.selectedBbmdForTree) {
-        const selectedBbmdLabel = nodeMap[this.selectedBbmdForTree]?.label
+      // Draw BDT/FDT edges in tree mode
+      // Always show these connections; highlight edges for selected BBMD
+      {
+        const selectedBbmdLabel = this.selectedBbmdForTree
+          ? nodeMap[this.selectedBbmdForTree]?.label
+          : null
 
         edges.forEach(edge => {
-          // Only draw BDT/FDT edges
           if (!edge.label) return
           const isBdt = edge.label.includes('bdt-entry')
           const isFdt = edge.label.includes('fdr-entry')
           if (!isBdt && !isFdt) return
-
-          // Check if this edge connects to the selected BBMD
-          const fromLabel = nodeMap[edge.from]?.label
-          const toLabel = nodeMap[edge.to]?.label
-
-          if (fromLabel !== selectedBbmdLabel && toLabel !== selectedBbmdLabel)
-            return
 
           const fromPos = networkInstance.getPosition(edge.from)
           const toPos = networkInstance.getPosition(edge.to)
 
           if (!fromPos || !toPos) return
 
+          // Determine if this edge connects to the selected BBMD (for highlighting)
+          const fromLabel = nodeMap[edge.from]?.label
+          const toLabel = nodeMap[edge.to]?.label
+          const isHighlighted = selectedBbmdLabel &&
+            (fromLabel === selectedBbmdLabel || toLabel === selectedBbmdLabel)
+
+          const opacity = isHighlighted ? 0.9 : 0.5
+
           // Different styles for BDT vs FDT
           if (isBdt) {
-            canvasContext.strokeStyle = 'rgba(255, 165, 0, 0.9)' // Orange for BDT
-            canvasContext.setLineDash([6, 4]) // Dashed
+            canvasContext.strokeStyle = `rgba(255, 165, 0, ${opacity})` // Orange for BDT
+            canvasContext.setLineDash([6, 4])
           } else {
-            canvasContext.strokeStyle = 'rgba(0, 200, 255, 0.9)' // Cyan for FDT
-            canvasContext.setLineDash([4, 2]) // Shorter dash
+            canvasContext.strokeStyle = `rgba(0, 200, 255, ${opacity})` // Cyan for FDT
+            canvasContext.setLineDash([4, 2])
           }
           canvasContext.lineWidth = 2
 
-          // Determine routing based on relative positions
-          const topNode = fromPos.y < toPos.y ? fromPos : toPos
-          const bottomNode = fromPos.y < toPos.y ? toPos : fromPos
+          // Route above both nodes with orthogonal path
+          const midY = Math.min(fromPos.y, toPos.y) - 40
+          const points = [
+            { x: fromPos.x, y: fromPos.y - 20 },
+            { x: fromPos.x, y: midY },
+            { x: toPos.x, y: midY },
+            { x: toPos.x, y: toPos.y - 20 }
+          ]
 
           canvasContext.beginPath()
-          if (isBdt || Math.abs(fromPos.y - toPos.y) < 50) {
-            // BDT or same-level: route above both nodes
-            const midY = Math.min(fromPos.y, toPos.y) - 40
-            canvasContext.moveTo(fromPos.x, fromPos.y - 20)
-            canvasContext.lineTo(fromPos.x, midY)
-            canvasContext.lineTo(toPos.x, midY)
-            canvasContext.lineTo(toPos.x, toPos.y - 20)
-          } else {
-            // FDT with level difference: route from BBMD down to device
-            // Go down from top node, across, then to bottom node
-            const midY = topNode.y + 40
-            canvasContext.moveTo(topNode.x, topNode.y + 20)
-            canvasContext.lineTo(topNode.x, midY)
-            canvasContext.lineTo(bottomNode.x, midY)
-            canvasContext.lineTo(bottomNode.x, bottomNode.y - 20)
-          }
+          canvasContext.moveTo(points[0].x, points[0].y)
+          canvasContext.lineTo(points[1].x, points[1].y)
+          canvasContext.lineTo(points[2].x, points[2].y)
+          canvasContext.lineTo(points[3].x, points[3].y)
           canvasContext.stroke()
+          storeEdgeGeometry(edge, points)
         })
 
-        canvasContext.setLineDash([]) // Reset line dash
+        canvasContext.setLineDash([])
       }
 
       canvasContext.restore()

--- a/grasshopper-frontend/src/components/NetworkDiagram.vue
+++ b/grasshopper-frontend/src/components/NetworkDiagram.vue
@@ -845,6 +845,48 @@ export default {
         }
       })
 
+      // Step 5: Position Grasshopper next to its primary (nearest connected) subnet
+      // rather than as an isolated orphan at the far edge of the layout
+      const grasshopperNodes = nodes.filter(n => n.id.startsWith('bacnet://Grasshopper'))
+      grasshopperNodes.forEach(ghNode => {
+        // Find subnets connected to this Grasshopper node
+        const connectedSubnets = edges
+          .filter(e => e.from === ghNode.id || e.to === ghNode.id)
+          .map(e => e.from === ghNode.id ? e.to : e.from)
+          .filter(id => id.startsWith('bacnet://subnet/') && positions[id])
+
+        if (connectedSubnets.length > 0 && positions[ghNode.id]) {
+          // Find the nearest connected subnet by current position
+          let nearestSubnet = connectedSubnets[0]
+          let nearestDist = Infinity
+          connectedSubnets.forEach(subnetId => {
+            const dist = Math.abs(positions[ghNode.id].x - positions[subnetId].x)
+            if (dist < nearestDist) {
+              nearestDist = dist
+              nearestSubnet = subnetId
+            }
+          })
+
+          // Find the rightmost node in the subnet's subtree to place Grasshopper after it
+          const subnetChildren = parentToChildren[nearestSubnet] || []
+          let maxSubtreeX = positions[nearestSubnet].x
+          const getAllDescendantPositions = (nodeId) => {
+            if (positions[nodeId]) {
+              maxSubtreeX = Math.max(maxSubtreeX, positions[nodeId].x)
+            }
+            const children = parentToChildren[nodeId] || []
+            children.forEach(cid => getAllDescendantPositions(cid))
+          }
+          subnetChildren.forEach(cid => getAllDescendantPositions(cid))
+
+          // Place Grasshopper to the right of the subnet's subtree at the subnet level
+          positions[ghNode.id] = {
+            x: maxSubtreeX + nodeSpacing * 1.5,
+            y: positions[nearestSubnet].y,
+          }
+        }
+      })
+
       // Store the parent-child relationships and adjusted levels for edge drawing
       this.layoutParentChild = {
         childToParent,
@@ -1177,44 +1219,7 @@ export default {
         }
       })
 
-      // Special handling for Grasshopper node - draw its subnet connection
-      // Grasshopper is at level 1 (same as subnet) so it gets skipped by parent-child logic
-      edges.forEach(edge => {
-        const fromIsGrasshopper = edge.from.startsWith('bacnet://Grasshopper')
-        const toIsGrasshopper = edge.to.startsWith('bacnet://Grasshopper')
-
-        if (!fromIsGrasshopper && !toIsGrasshopper) return
-
-        const grasshopperId = fromIsGrasshopper ? edge.from : edge.to
-        const otherId = fromIsGrasshopper ? edge.to : edge.from
-
-        // Only draw subnet connections (same level)
-        if (!otherId.startsWith('bacnet://subnet/')) return
-
-        const grasshopperPos = networkInstance.getPosition(grasshopperId)
-        const subnetPos = networkInstance.getPosition(otherId)
-
-        if (!grasshopperPos || !subnetPos) return
-
-        // Grasshopper connections in teal/cyan
-        canvasContext.strokeStyle = 'rgba(0, 180, 180, 0.9)'
-        canvasContext.lineWidth = 2
-        canvasContext.setLineDash([])
-
-        // Draw horizontal line connecting Grasshopper to subnet at same level
-        const points = [
-          { x: grasshopperPos.x, y: grasshopperPos.y },
-          { x: subnetPos.x, y: subnetPos.y }
-        ]
-        canvasContext.beginPath()
-        canvasContext.moveTo(points[0].x, points[0].y)
-        canvasContext.lineTo(points[1].x, points[1].y)
-        canvasContext.stroke()
-        storeEdgeGeometry(edge, points)
-      })
-
-      // Draw any edges not covered by childToParent (same-level connections, etc.)
-      // This catches edges between nodes at the same level or edges missed by the hierarchy
+      // Track drawn edges to avoid double-drawing in the catch-all section below
       const drawnEdges = new Set()
       Object.keys(childToParent).forEach(childId => {
         const parentId = childToParent[childId]
@@ -1222,8 +1227,68 @@ export default {
         drawnEdges.add(`${childId}-${parentId}`)
       })
 
+      // Special handling for Grasshopper node - draw its subnet connection
+      // Grasshopper is at level 1 (same as subnet) so it gets skipped by parent-child logic
+      // Only draw to the nearest subnet (the one Grasshopper is directly on).
+      // Connectivity to other subnets is via BDT entries shown through BBMD edges.
+      const grasshopperSubnetEdges = edges.filter(edge => {
+        const fromIsGrasshopper = edge.from.startsWith('bacnet://Grasshopper')
+        const toIsGrasshopper = edge.to.startsWith('bacnet://Grasshopper')
+        if (!fromIsGrasshopper && !toIsGrasshopper) return false
+        const otherId = fromIsGrasshopper ? edge.to : edge.from
+        return otherId.startsWith('bacnet://subnet/')
+      })
+
+      // Find the nearest subnet to Grasshopper (the one it's physically on)
+      let nearestSubnetEdge = null
+      let nearestDist = Infinity
+      grasshopperSubnetEdges.forEach(edge => {
+        const fromIsGrasshopper = edge.from.startsWith('bacnet://Grasshopper')
+        const grasshopperId = fromIsGrasshopper ? edge.from : edge.to
+        const subnetId = fromIsGrasshopper ? edge.to : edge.from
+        const grasshopperPos = networkInstance.getPosition(grasshopperId)
+        const subnetPos = networkInstance.getPosition(subnetId)
+        if (!grasshopperPos || !subnetPos) return
+        const dist = Math.abs(grasshopperPos.x - subnetPos.x) + Math.abs(grasshopperPos.y - subnetPos.y)
+        if (dist < nearestDist) {
+          nearestDist = dist
+          nearestSubnetEdge = edge
+        }
+        // Track ALL Grasshopper-subnet edges as drawn so catch-all skips them
+        drawnEdges.add(`${edge.from}-${edge.to}`)
+        drawnEdges.add(`${edge.to}-${edge.from}`)
+      })
+
+      if (nearestSubnetEdge) {
+        const fromIsGrasshopper = nearestSubnetEdge.from.startsWith('bacnet://Grasshopper')
+        const grasshopperId = fromIsGrasshopper ? nearestSubnetEdge.from : nearestSubnetEdge.to
+        const subnetId = fromIsGrasshopper ? nearestSubnetEdge.to : nearestSubnetEdge.from
+        const grasshopperPos = networkInstance.getPosition(grasshopperId)
+        const subnetPos = networkInstance.getPosition(subnetId)
+
+        if (grasshopperPos && subnetPos) {
+          // Grasshopper connections in teal/cyan
+          canvasContext.strokeStyle = 'rgba(0, 180, 180, 0.9)'
+          canvasContext.lineWidth = 2
+          canvasContext.setLineDash([])
+
+          // Draw horizontal line connecting Grasshopper to its nearest subnet
+          const points = [
+            { x: grasshopperPos.x, y: grasshopperPos.y },
+            { x: subnetPos.x, y: subnetPos.y }
+          ]
+          canvasContext.beginPath()
+          canvasContext.moveTo(points[0].x, points[0].y)
+          canvasContext.lineTo(points[1].x, points[1].y)
+          canvasContext.stroke()
+          storeEdgeGeometry(nearestSubnetEdge, points)
+        }
+      }
+
+      // Draw any edges not covered by childToParent or Grasshopper handler
+      // This catches edges between nodes at the same level or edges missed by the hierarchy
       edges.forEach(edge => {
-        // Skip if already drawn via childToParent
+        // Skip if already drawn via childToParent or Grasshopper handler
         if (drawnEdges.has(`${edge.from}-${edge.to}`)) return
 
         // Skip BDT/FDT entries (BBMD connections) - handled separately when BBMD selected


### PR DESCRIPTION
## Summary
- Builds the BACpypes3 Application stack manually in `set_application` to pass a pre-bound UDP socket with `SO_REUSEPORT` + `SO_REUSEADDR` + `SO_BROADCAST` to the IPv4 link layer
- Uses upstream bacpypes3 `bind_socket` support (`NormalLinkLayer -> IPv4DatagramServer`) instead of the ACE fork's `grasshopper-bandage` branch
- Restores ability for multiple BACnet applications to share the same broadcast port (47808) on bare-metal hosts

## Context
The auto-addressing changes broke the socket passthrough that allowed `SO_REUSEPORT`. The ACE fork (`grasshopper-bandage`) was a temporary workaround — upstream now supports `bind_socket` natively, so we build the socket in Grasshopper and pass it in.

## Test plan
- [ ] Verify container starts and scans BACnet network successfully
- [ ] Verify two BACnet applications can bind to port 47808 simultaneously on a bare-metal host
- [ ] Verify graph building works correctly with upstream bacpypes3

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)